### PR TITLE
Fix default grpc-gateway options to allow override error handlers

### DIFF
--- a/pkg/grapiserver/gateway.go
+++ b/pkg/grapiserver/gateway.go
@@ -70,8 +70,8 @@ func (s *GatewayServer) createConn() (conn *grpc.ClientConn, err error) {
 func (s *GatewayServer) createServer(conn *grpc.ClientConn) (*http.Server, error) {
 	mux := runtime.NewServeMux(
 		append(
-			s.GatewayMuxOptions,
-			runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler),
+			[]runtime.ServeMuxOption{runtime.WithProtoErrorHandler(runtime.DefaultHTTPProtoErrorHandler)},
+			s.GatewayMuxOptions...,
 		)...,
 	)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)


### PR DESCRIPTION
## WHY

## WHAT

## REF

