### PR TITLE
Simplify build pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,11 +61,6 @@ jobs:
     script: skip
     before_deploy:
     - make packages
-    # for canary build, ref: https://github.com/oliexdev/openScale/pull/121
-    - git remote add gh https://${TRAVIS_REPO_SLUG%/*}:${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
-    - git tag -f $CANARY_TAG
-    - git push -f gh $CANARY_TAG
-    - git remote remove gh
     deploy:
     - provider: releases
       skip_cleanup: true
@@ -74,16 +69,4 @@ jobs:
       file: $FILE_TO_DEPLOY
       on:
         tags: true
-    - provider: releases
-      skip_cleanup: true
-      api_key: $GITHUB_TOKEN
-      file_glob: true
-      file: $FILE_TO_DEPLOY
-      prerelease: true
-      overwrite: true
-      name: canary
-      body: canary build of $TRAVIS_BRANCH ($TRAVIS_COMMIT) built by Travis CI on $(date +'%F %T %Z').
-      target_commitish: $TRAVIS_COMMIT
-      on:
-        branch: master
     if: type != 'pull_request'

--- a/Makefile
+++ b/Makefile
@@ -1,69 +1,39 @@
+PATH := ${PWD}/bin:${PATH}
+export PATH
+
 .DEFAULT_GOAL := all
 
-VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 2
-VERSION_BUILD ?= 2
-
-VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
 REVISION ?= $(shell git describe --always)
 BUILD_DATE ?= $(shell date +'%Y-%m-%dT%H:%M:%SZ')
-RELEASE_TYPE ?= $(if $(shell git tag --contains $(REVISION) | grep $(VERSION)),stable,canary)
-
-ORG := github.com/izumin5210
-PROJECT := grapi
-ROOT_PKG ?= $(ORG)/$(PROJECT)
-
-TEMPLATE_PKG := pkg/grapicmd/internal/module/generator/template
-MOCK_PKG := pkg/grapicmd/internal/module/testing
-GENERATED_PKGS := $(TEMPLATE_PKG)
-GENERATED_PKGS += $(MOCK_PKG)
-
-SRC_FILES := $(shell git ls-files --cached --others --exclude-standard | grep -E "\.go$$" | grep -v ".snapshot")
-GOFMT_TARGET := $(SRC_FILES)
-$(foreach pkg,$(GENERATED_PKGS),$(eval GOFMT_TARGET := $(filter-out $(pkg)/%,$(GOFMT_TARGET))))
-GOLINT_TARGET := $(shell go list ./... | grep -v "$(pkg)/testing")
-$(foreach pkg,$(GENERATED_PKGS),$(eval GOLINT_TARGET := $(filter-out $(ROOT_PKG)/$(pkg),$(GOLINT_TARGET))))
 
 GO_BUILD_FLAGS := -v
 GO_TEST_FLAGS := -v -timeout 30s
 GO_TEST_INTEGRATION_FLAGS := -v
-GO_COVER_FLAGS := -coverpkg $(shell echo $(GOLINT_TARGET) | tr ' ' ',') -coverprofile coverage.txt -covermode atomic
+GO_COVER_FLAGS := -coverprofile coverage.txt -covermode atomic
+SRC_FILES := $(shell go list -f '{{range .GoFiles}}{{printf "%s/%s\n" $$.Dir .}}{{end}}' ./...)
 
 XC_ARCH := 386 amd64
 XC_OS := darwin linux windows
 
-PATH := ${PWD}/bin:${PATH}
-export PATH
-
-#  Utils
-#----------------------------------------------------------------
-define section
-  @printf "\e[34m--> $1\e[0m\n"
-endef
-
 
 #  App
 #----------------------------------------------------------------
-BIN_DIR := ./bin/
+BIN_DIR := ./bin
 OUT_DIR := ./dist
 GENERATED_BINS :=
 PACKAGES :=
-CMDS := $(wildcard ./cmd/*)
 
 define cmd-tmpl
 
 $(eval NAME := $(notdir $(1)))
-$(eval OUT := $(addprefix $(BIN_DIR),$(NAME)))
-$(eval LDFLAGS := -ldflags "-X main.name=$(NAME) -X main.version=$(VERSION) -X main.revision=$(REVISION) -X main.buildDate=$(BUILD_DATE) -X main.releaseType=$(RELEASE_TYPE)")
-$(eval GENERATED_BINS += $(OUT))
+$(eval OUT := $(addprefix $(BIN_DIR)/,$(NAME)))
+$(eval LDFLAGS := -ldflags "-X main.revision=$(REVISION) -X main.buildDate=$(BUILD_DATE)")
+
 $(OUT): $(SRC_FILES)
-	$(call section,Building $(OUT))
-	@go build $(GO_BUILD_FLAGS) $(LDFLAGS) -o $(OUT) $(1)
+	go build $(GO_BUILD_FLAGS) $(LDFLAGS) -o $(OUT) $(1)
 
 .PHONY: $(NAME)
 $(NAME): $(OUT)
-
-$(eval PACKAGES += $(NAME)-package)
 
 .PHONY: $(NAME)-package
 $(NAME)-package: $(NAME) $(BIN_DIR)/gox
@@ -73,22 +43,19 @@ $(NAME)-package: $(NAME) $(BIN_DIR)/gox
 		-arch="$(XC_ARCH)" \
 		-output="$(OUT_DIR)/$(NAME)_{{.OS}}_{{.Arch}}" \
 		$(1)
+
+$(eval GENERATED_BINS += $(OUT))
+$(eval PACKAGES += $(NAME)-package)
+
 endef
 
-$(foreach src,$(CMDS),$(eval $(call cmd-tmpl,$(src))))
-
-.PHONY: all
-all: $(GENERATED_BINS)
+$(foreach src,$(wildcard ./cmd/*),$(eval $(call cmd-tmpl,$(src))))
 
 
 #  Commands
 #----------------------------------------------------------------
-$(BIN_DIR)/mockgen $(BIN_DIR)/go-assets-builder $(BIN_DIR)/gox: $(BIN_DIR)/gex
-	gex --build
-
 .PHONY: setup
 setup:
-	@go get github.com/izumin5210/gex/cmd/gex
 ifeq ($(shell go env GOMOD),)
 ifdef CI
 	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -97,18 +64,19 @@ endif
 else
 	go get -v ./...
 endif
+	@go get github.com/izumin5210/gex/cmd/gex
+	gex --build --verbose
 
 .PHONY: clean
 clean:
 	rm -rf $(BIN_DIR)/*
 
 .PHONY: gen
-gen: $(BIN_DIR)/mockgen $(BIN_DIR)/go-assets-builder
+gen:
 	go generate ./...
 
 .PHONY: lint
 lint:
-	$(call section,Linting)
 ifdef CI
 	gex reviewdog -reporter=github-pr-review
 else
@@ -117,18 +85,18 @@ endif
 
 .PHONY: test
 test:
-	$(call section,Testing)
-	@go test $(GO_TEST_FLAGS) ./...
+	go test $(GO_TEST_FLAGS) ./...
 
 .PHONY: cover
 cover:
-	$(call section,Testing with coverage)
-	@go test $(GO_TEST_FLAGS) $(GO_COVER_FLAGS) ./...
+	go test $(GO_TEST_FLAGS) $(GO_COVER_FLAGS) ./...
 
 .PHONY: test-integration
 test-integration: $(GENERATED_BINS)
-	$(call section,Integration Testing)
 	cd _tests && go test $(GO_TEST_INTEGRATION_FLAGS) ./...
+
+.PHONY: all
+all: $(GENERATED_BINS)
 
 .PHONY: packages
 packages: $(PACKAGES)

--- a/cmd/grapi/consts.go
+++ b/cmd/grapi/consts.go
@@ -1,0 +1,18 @@
+package main
+
+const (
+	name    = "grapi"
+	version = "v0.2.2"
+)
+
+var (
+	prebuilt bool
+
+	// set via ldflags
+	revision  string
+	buildDate string
+)
+
+func init() {
+	prebuilt = revision != ""
+}

--- a/cmd/grapi/main.go
+++ b/cmd/grapi/main.go
@@ -12,13 +12,6 @@ import (
 )
 
 var (
-	name      string
-	version   string
-	revision  string
-	buildDate string
-
-	releaseType string
-
 	inReader            = os.Stdin
 	outWriter io.Writer = os.Stdout
 	errWriter io.Writer = os.Stderr
@@ -28,9 +21,6 @@ func init() {
 	if runtime.GOOS == "windows" {
 		outWriter = colorable.NewColorableStdout()
 		errWriter = colorable.NewColorableStderr()
-	}
-	if name == "" {
-		name = "grapi"
 	}
 }
 
@@ -46,7 +36,7 @@ func main() {
 		version,
 		revision,
 		buildDate,
-		releaseType,
+		prebuilt,
 		inReader,
 		outWriter,
 		errWriter,

--- a/pkg/grapicmd/cmd/version.go
+++ b/pkg/grapicmd/cmd/version.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/izumin5210/grapi/pkg/grapicmd"
@@ -14,7 +17,12 @@ func newVersionCommand(cfg grapicmd.Config) *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Run: func(cmd *cobra.Command, _ []string) {
-			cmd.Printf("%s %s %s (%s %s)\n", cfg.AppName(), cfg.Version(), cfg.ReleaseType(), cfg.BuildDate(), cfg.Revision())
+			buf := bytes.NewBufferString(cfg.AppName() + " " + cfg.Version())
+			if cfg.Prebuilt() {
+				buf.WriteString(" (" + cfg.BuildDate() + " " + cfg.Revision() + ")")
+			}
+			buf.WriteString("\n")
+			fmt.Fprintf(cfg.OutWriter(), buf.String())
 		},
 	}
 }

--- a/pkg/grapicmd/config.go
+++ b/pkg/grapicmd/config.go
@@ -21,7 +21,7 @@ type Config interface {
 	Version() string
 	Revision() string
 	BuildDate() string
-	ReleaseType() string
+	Prebuilt() bool
 	InReader() io.Reader
 	OutWriter() io.Writer
 	ErrWriter() io.Writer
@@ -33,41 +33,43 @@ type Config interface {
 // NewConfig creates new Config object.
 func NewConfig(
 	currentDir string,
-	appName, version, revision string,
-	buildDate, releaseType string,
+	appName, version string,
+	revision, buildDate string,
+	prebuilt bool,
 	in io.Reader,
 	out, err io.Writer,
 ) Config {
 	afs := afero.NewOsFs()
 	rootDir, insideApp := fs.LookupRoot(afs, currentDir)
 	return &config{
-		v:           viper.New(),
-		fs:          afs,
-		currentDir:  currentDir,
-		rootDir:     rootDir,
-		insideApp:   insideApp,
-		appName:     appName,
-		version:     version,
-		revision:    revision,
-		buildDate:   buildDate,
-		releaseType: releaseType,
-		in:          in,
-		out:         out,
-		err:         err,
+		v:          viper.New(),
+		fs:         afs,
+		currentDir: currentDir,
+		rootDir:    rootDir,
+		insideApp:  insideApp,
+		appName:    appName,
+		version:    version,
+		revision:   revision,
+		buildDate:  buildDate,
+		prebuilt:   prebuilt,
+		in:         in,
+		out:        out,
+		err:        err,
 	}
 }
 
 type config struct {
-	cfgFile                    string
-	v                          *viper.Viper
-	fs                         afero.Fs
-	currentDir, rootDir        string
-	insideApp                  bool
-	appName, version, revision string
-	buildDate, releaseType     string
-	in                         io.Reader
-	out, err                   io.Writer
-	readConfigErr              error
+	cfgFile             string
+	v                   *viper.Viper
+	fs                  afero.Fs
+	currentDir, rootDir string
+	insideApp           bool
+	appName, version    string
+	revision, buildDate string
+	prebuilt            bool
+	in                  io.Reader
+	out, err            io.Writer
+	readConfigErr       error
 }
 
 func (c *config) Init(cfgFile string) {
@@ -108,8 +110,8 @@ func (c *config) BuildDate() string {
 	return c.buildDate
 }
 
-func (c *config) ReleaseType() string {
-	return c.releaseType
+func (c *config) Prebuilt() bool {
+	return c.prebuilt
 }
 
 func (c *config) InReader() io.Reader {


### PR DESCRIPTION
## WHY

when `go get github.com/izumin5210/grapi/cmd/grapi`, `grapi verison` prints meaningless output...


## WHAT

set an app name and a version via a `.go` file.

this change allows to install `grapi` w/ `go get`, so i stop canary release on CI pipeline.