### PR TITLE
Fix the position of [flags] in grapi build command's usage

### DIFF
--- a/pkg/grapicmd/cmd/build.go
+++ b/pkg/grapicmd/cmd/build.go
@@ -11,7 +11,7 @@ import (
 
 func newBuildCommand(ctx *grapicmd.Ctx) *cobra.Command {
 	return &cobra.Command{
-		Use:           "build [TARGET]... [-- BUILD_OPTIONS]",
+		Use:           "build [flags] [TARGET]... [-- BUILD_OPTIONS]",
 		Short:         "Build commands",
 		SilenceErrors: true,
 		SilenceUsage:  true,


### PR DESCRIPTION
## WHY
The following is displayed by `grapi build -h`.
```
❯ grapi build -h
Build commands

Usage:
  grapi build [TARGET]... [-- BUILD_OPTIONS] [flags]

Flags:
  -h, --help   help for build

Global Flags:
      --debug     Debug level output
  -v, --verbose   Verbose level output
```
However, the appearance of [flags] after [-- BUILD_OPTIONS] is obviously a strange notation.

## WHAT
I changed it so that [flags] is displayed before [TARGET].