### PR TITLE
Trigger CI on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,14 @@ jobs:
 
     - run: go mod download
 
+    - run: echo "::set-env name=TARGET_REVISION::${{ github.sha }}"
+      if: "github.event.push"
+
+    - run: echo "::set-env name=GRAPI_URL::$(pwd)"
+      if: "!github.event.push"
+
     - run: make ${{ matrix.test-task }}
       env:
-        TARGET_REVISION: ${{ github.sha }}
         COVER: ${{ matrix.go-version == '1.13.x' && matrix.test-task == 'test' }} 
 
     - run: curl -s https://codecov.io/bash | bash -s -- -t $CODECOV_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 .PHONY: test-e2e
 test-e2e: build
-	go test -v -timeout 4m ./_tests/e2e --grapi=$$PWD/bin/grapi --revision="$(TARGET_REVISION)"
+	go test -v -timeout 4m ./_tests/e2e --grapi=$$PWD/bin/grapi --grapi-url="$(GRAPI_URL)" --revision="$(TARGET_REVISION)"
 
 # linters
 bin/reviewdog:

--- a/_tests/e2e/main_test.go
+++ b/_tests/e2e/main_test.go
@@ -26,6 +26,7 @@ import (
 
 var (
 	grapiCmd = flag.String("grapi", "grapi", "path of grapi command")
+	grapiURL = flag.String("grapi-url", "", "url for replacing github.com/izumin5210/grapi")
 	revision = flag.String("revision", "", "target revision")
 )
 
@@ -53,7 +54,10 @@ func invokeE2ETest(t *testing.T, exporter packagestest.Exporter) {
 	// init
 	{
 		args := []string{"--debug", "init", "--package", "testuser.sampleapp"}
-		if *revision != "" {
+		if *grapiURL != "" {
+			// Add replacements later
+			args = append(args, "--replace-grapi="+*grapiURL)
+		} else if *revision != "" {
 			args = append(args, "--revision="+*revision)
 		} else {
 			args = append(args, "--HEAD")

--- a/pkg/grapicmd/cmd/init.go
+++ b/pkg/grapicmd/cmd/init.go
@@ -42,6 +42,7 @@ func newInitCommand(ctx *grapicmd.Ctx) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&cfg.Branch, "branch", "", "Specify grapi branch")
 	cmd.PersistentFlags().StringVar(&cfg.Version, "version", "", "Specify grapi version")
 	cmd.PersistentFlags().BoolVar(&cfg.HEAD, "HEAD", false, "Use HEAD grapi")
+	cmd.PersistentFlags().StringVar(&cfg.GrapiReplacementURL, "replace-grapi", "", "Specify grapi replacement url")
 	cmd.PersistentFlags().StringVarP(&cfg.Package, "package", "p", "", `Package name of the application(default: "<parent_package_or_username>.<app_name>")`)
 	cmd.PersistentFlags().BoolVar(&cfg.Dep, "use-dep", false, "Use dep instead of Modules")
 

--- a/pkg/grapicmd/internal/usecase/init_config.go
+++ b/pkg/grapicmd/internal/usecase/init_config.go
@@ -3,12 +3,13 @@ package usecase
 import "bytes"
 
 type InitConfig struct {
-	Revision string
-	Branch   string
-	Version  string
-	HEAD     bool
-	Package  string
-	Dep      bool
+	Revision            string
+	Branch              string
+	Version             string
+	HEAD                bool
+	GrapiReplacementURL string
+	Package             string
+	Dep                 bool
 }
 
 func (c *InitConfig) BuildSpec() string {

--- a/pkg/grapicmd/internal/usecase/initialize_project_usecase.go
+++ b/pkg/grapicmd/internal/usecase/initialize_project_usecase.go
@@ -120,7 +120,12 @@ func (u *initializeProjectUsecase) InstallDeps(rootDir string, cfg InitConfig) e
 			u.ui.ItemFailure("--version, --revision, --branch and --HEAD are not supported in dep mode")
 		}
 	} else {
-		if spec := cfg.BuildSpec(); spec != "" {
+		if cfg.GrapiReplacementURL != "" {
+			err := invoke("go", "mod", "edit", "-replace", "github.com/izumin5210/grapi=" + cfg.GrapiReplacementURL)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		} else if spec := cfg.BuildSpec(); spec != "" {
 			pkg := "github.com/izumin5210/grapi/pkg/grapiserver"
 			err := invoke("go", "get", pkg+spec)
 			if err != nil {

--- a/pkg/grapicmd/internal/usecase/initialize_project_usecase.go
+++ b/pkg/grapicmd/internal/usecase/initialize_project_usecase.go
@@ -121,7 +121,7 @@ func (u *initializeProjectUsecase) InstallDeps(rootDir string, cfg InitConfig) e
 		}
 	} else {
 		if cfg.GrapiReplacementURL != "" {
-			err := invoke("go", "mod", "edit", "-replace", "github.com/izumin5210/grapi=" + cfg.GrapiReplacementURL)
+			err := invoke("go", "mod", "edit", "-replace", "github.com/izumin5210/grapi="+cfg.GrapiReplacementURL)
 			if err != nil {
 				return errors.WithStack(err)
 			}


### PR DESCRIPTION
"test" workflow is configured to run on `[push]` only, which means it won't be kicked on remote pull requests.

This pr expands the condition to `[push, pull_request]`.