### PR TITLE
Fix Build args parse

### DIFF
--- a/pkg/grapicmd/cmd/build.go
+++ b/pkg/grapicmd/cmd/build.go
@@ -11,11 +11,12 @@ import (
 	"github.com/izumin5210/grapi/pkg/grapicmd/di"
 )
 
-func getBuildOption(args []string) ([]string, []string) {
+func splitOptions(args []string) ([]string, []string) {
 	pos := len(args)
 	for i, arg := range args {
 		if strings.HasPrefix(arg, "-") {
 			pos = i
+
 			break
 		}
 	}
@@ -33,13 +34,13 @@ func newBuildCommand(ctx *grapicmd.Ctx) *cobra.Command {
 				return errors.New("protoc command should be execute inside a grapi application directory")
 			}
 
-			arg, opt := getBuildOption(args)
+			names, opt := splitOptions(args)
 
-			nameSet := make(map[string]bool, len(arg))
-			for _, n := range arg {
+			nameSet := make(map[string]bool, len(names))
+			for _, n := range names {
 				nameSet[n] = true
 			}
-			isAll := len(arg) == 0
+			isAll := len(names) == 0
 
 			scriptLoader := di.NewScriptLoader(ctx)
 			ui := di.NewUI(ctx)

--- a/pkg/grapicmd/cmd/build.go
+++ b/pkg/grapicmd/cmd/build.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/srvc/appctx"
@@ -8,6 +10,17 @@ import (
 	"github.com/izumin5210/grapi/pkg/grapicmd"
 	"github.com/izumin5210/grapi/pkg/grapicmd/di"
 )
+
+func getBuildOption(args []string) ([]string, []string) {
+	pos := len(args)
+	for i, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			pos = i
+			break
+		}
+	}
+	return args[:pos], args[pos:]
+}
 
 func newBuildCommand(ctx *grapicmd.Ctx) *cobra.Command {
 	return &cobra.Command{
@@ -20,11 +33,13 @@ func newBuildCommand(ctx *grapicmd.Ctx) *cobra.Command {
 				return errors.New("protoc command should be execute inside a grapi application directory")
 			}
 
-			nameSet := make(map[string]bool, len(args))
-			for _, n := range args {
+			arg, opt := getBuildOption(args)
+
+			nameSet := make(map[string]bool, len(arg))
+			for _, n := range arg {
 				nameSet[n] = true
 			}
-			isAll := len(args) == 0
+			isAll := len(arg) == 0
 
 			scriptLoader := di.NewScriptLoader(ctx)
 			ui := di.NewUI(ctx)
@@ -40,7 +55,7 @@ func newBuildCommand(ctx *grapicmd.Ctx) *cobra.Command {
 				script, ok := scriptLoader.Get(name)
 				if ok && (isAll || nameSet[script.Name()]) {
 					ui.Subsection("Building " + script.Name())
-					err := script.Build(ctx, args...)
+					err := script.Build(ctx, opt...)
 					if err != nil {
 						return errors.WithStack(err)
 					}

--- a/pkg/grapicmd/cmd/build_internal_test.go
+++ b/pkg/grapicmd/cmd/build_internal_test.go
@@ -1,6 +1,12 @@
 package cmd
 
 import (
+	"errors"
+	//"github.com/spf13/pflag"
+	"github.com/golang/mock/gomock"
+	"github.com/izumin5210/grapi/pkg/cli"
+	"github.com/izumin5210/grapi/pkg/grapicmd/internal/module/testing"
+
 	"reflect"
 	"testing"
 )
@@ -55,6 +61,112 @@ func TestSplitOptions(t *testing.T) {
 		}
 		if !reflect.DeepEqual(test.outputOpt, gotOpt) {
 			t.Errorf("(%v) Expected: %v gotOpt: %v", i, test.outputOpt, gotOpt)
+		}
+	}
+}
+
+func Test_newBuildCommandMocked(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cases := []struct {
+		args              []string
+		argsStriped       []string
+		opt               []string
+		scriptLoaderNames []string
+		hasNameSet        []bool
+		wantErr           bool
+		err               error
+	}{
+		{
+			args:              []string{"aaa", "bbb", "ccc", "--", "-a", "-b", "-c"},
+			argsStriped:       []string{"aaa", "bbb", "ccc"},
+			opt:               []string{"-a", "-b", "-c"},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{true, true, true},
+			wantErr:           true,
+			err:               errors.New("error occur"),
+		},
+		{
+			args:              []string{"aaa", "bbb", "ccc"},
+			argsStriped:       []string{"aaa", "bbb", "ccc"},
+			opt:               []string{},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{true, true, true},
+			wantErr:           false,
+			err:               nil,
+		},
+		{
+			args:              []string{"aaa"},
+			argsStriped:       []string{"aaa"},
+			opt:               []string{},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{true, false, false},
+			wantErr:           false,
+			err:               nil,
+		},
+		{
+			args:              []string{"aaa", "--", "-b", "c"},
+			argsStriped:       []string{"aaa"},
+			opt:               []string{"-b", "c"},
+			scriptLoaderNames: []string{"aaa"},
+			hasNameSet:        []bool{true},
+			wantErr:           true,
+			err:               errors.New("error occur"),
+		},
+		{
+			args:              []string{"--", "-a", "-b"},
+			argsStriped:       []string{},
+			opt:               []string{"-a", "-b"},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{false, false, false},
+			wantErr:           true,
+			err:               errors.New("error occur"),
+		},
+		{
+			args:              []string{"--", "-a", "b"},
+			argsStriped:       []string{},
+			opt:               []string{"-a", "b"},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{false, false, false},
+			wantErr:           true,
+			err:               errors.New("error occur"),
+		},
+		{
+			args:              []string{},
+			argsStriped:       []string{},
+			opt:               []string{},
+			scriptLoaderNames: []string{"aaa", "bbb", "ccc"},
+			hasNameSet:        []bool{false, false, false},
+			wantErr:           false,
+			err:               nil,
+		},
+	}
+
+	for _, c := range cases {
+		loader := moduletesting.NewMockScriptLoader(ctrl)
+
+		loader.EXPECT().Names().Return(c.scriptLoaderNames)
+
+		for i, arg := range c.scriptLoaderNames {
+			script := moduletesting.NewMockScript(ctrl)
+			loader.EXPECT().Get(arg).Return(script, true)
+			script.EXPECT().Name().Return(arg).AnyTimes()
+
+			if len(c.argsStriped) == 0 || c.hasNameSet[i] {
+				script.EXPECT().Build(gomock.Any(), c.opt).Return(c.err)
+			}
+			if c.err != nil {
+				break
+			}
+		}
+
+		cmd := newBuildCommandMocked(loader, cli.NopUI)
+		cmd.SetArgs(c.args)
+		err := cmd.Execute()
+
+		if c.wantErr != (err != nil) {
+			t.Errorf("wantErr: %v, gotErr: %v", c.wantErr, err != nil)
 		}
 	}
 }

--- a/pkg/grapicmd/cmd/build_internal_test.go
+++ b/pkg/grapicmd/cmd/build_internal_test.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitOptions(t *testing.T) {
+	tests := []struct {
+		input     []string
+		outputArg []string
+		outputOpt []string
+	}{
+		{
+			[]string{"foo", "bar"},
+			[]string{"foo", "bar"},
+			[]string{},
+		},
+		{
+			[]string{"foo", "-b"},
+			[]string{"foo"},
+			[]string{"-b"},
+		},
+		{
+			[]string{"foo", "-b", "-h"},
+			[]string{"foo"},
+			[]string{"-b", "-h"},
+		},
+		{
+			[]string{"foo", "-b", "-h"},
+			[]string{"foo"},
+			[]string{"-b", "-h"},
+		},
+		{
+			[]string{"-b", "-h"},
+			[]string{},
+			[]string{"-b", "-h"},
+		},
+		{
+			[]string{"foo", "-b", "-h", "ooo"},
+			[]string{"foo"},
+			[]string{"-b", "-h", "ooo"},
+		},
+		{
+			[]string{},
+			[]string{},
+			[]string{},
+		},
+	}
+
+	for i, test := range tests {
+		gotArg, gotOpt := splitOptions(test.input)
+		if !reflect.DeepEqual(test.outputArg, gotArg) {
+			t.Errorf("(%v) Expected: %v gotArg: %v", i, test.outputArg, gotArg)
+		}
+		if !reflect.DeepEqual(test.outputOpt, gotOpt) {
+			t.Errorf("(%v) Expected: %v gotOpt: %v", i, test.outputOpt, gotOpt)
+		}
+	}
+}


### PR DESCRIPTION
## WHY
#235 
`grapi build [TARGET]` fails. And can't pass `[BUILD_ARGS]` to `go build`command.

## WHAT
- fix argument parse
- change testable code
- pass build option to `go build` command