### PR TITLE
Don't use set-env command which is deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
 
     - run: go mod download
 
-    - run: echo "::set-env name=TARGET_REVISION::${{ github.sha }}"
+    - run: echo "TARGET_REVISION=${{ github.sha }}" >> $GITHUB_ENV
       if: "github.event.push"
 
-    - run: echo "::set-env name=GRAPI_URL::$(pwd)"
+    - run: echo "GRAPI_URL=$(pwd)" >> $GITHUB_ENV
       if: "!github.event.push"
 
     - run: make ${{ matrix.test-task }}


### PR DESCRIPTION
## Why
CI fails, regardless of code tests, because of using the `set-env` command deprecated last October.

## What
Use an alternative way to set env vars.

Ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/