### PR TITLE
Route the "PATCH" HTTP method to the gateway

### DIFF
--- a/pkg/grapiserver/cmux.go
+++ b/pkg/grapiserver/cmux.go
@@ -33,5 +33,5 @@ func (s *cmuxServer) GRPCListener() net.Listener {
 }
 
 func (s *cmuxServer) HTTPListener() net.Listener {
-	return s.mux.Match(cmux.HTTP2(), cmux.HTTP1Fast())
+	return s.mux.Match(cmux.HTTP2(), cmux.HTTP1Fast("PATCH"))
 }


### PR DESCRIPTION
This is a common REST method, and without this change, it's impossible to send the "PATCH" method over HTTP in configurations where the HTTP Gateway and the GRPC Gateway (e.g., the default configuration).

Resolves #301.