### PR TITLE
Rerost/support only two version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: ['1.11.x', '1.12.x', '1.13.x']
+        go-version: ['1.22.x', '1.23.x']
         test-task: ['test', 'test-e2e']
 
     steps:
@@ -37,17 +37,17 @@ jobs:
 
     - run: make ${{ matrix.test-task }}
       env:
-        COVER: ${{ matrix.go-version == '1.13.x' && matrix.test-task == 'test' }} 
+        COVER: ${{ matrix.go-version == '1.23.x' && matrix.test-task == 'test' }} 
 
     - run: curl -s https://codecov.io/bash | bash -s -- -t $CODECOV_TOKEN
-      if: matrix.go-version == '1.13.x' && matrix.test-task == 'test'
+      if: matrix.go-version == '1.23.x' && matrix.test-task == 'test'
 
   build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.23
 
     - uses: actions/checkout@v1
 

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9G
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5 h1:2+KSC78XiO6Qy0hIjfc1OD9H+hsaJdJlb8Kqsd41CTE=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u+Tmr2evNHDiI=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -180,6 +181,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2 h1:VUFqw5KcqRf7i70GOzW7N+Q7+gxVBkSSqiXB12+JQ4M=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/spf13/viper v1.4.0 h1:yXHLWeravcrgGyFSyCgdYpXQ9dR9c/WED3pg1RhxqEU=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/srvc/appctx v0.1.0 h1:x44Sw4dU567bIWMl5U70XxBrSxxJGzu2DI2zcaljdCA=
 github.com/srvc/appctx v0.1.0/go.mod h1:CrplkHjXk2n2wl7wKlDIX5mZdrch9feYZlu32ubJvPA=


### PR DESCRIPTION
Since the current version of Go we are using is outdated, I propose that we support the latest two major releases in accordance with Go's official release policy (https://go.dev/doc/devel/release#policy).